### PR TITLE
feat: handle multiValueHeaders in resolver

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@serverless-devs/fc-http",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,10 @@ const makeResolver = (ctx) => {
         response.setHeader(key, value);
       }
     }
+    for (const key in data.multiValueHeaders) {
+      const value = data.multiValueHeaders[key]
+      response.setHeader(key, value)
+    }
     if (response.send) {
       response.send(data.body);
     } else {


### PR DESCRIPTION
将serverlessHandler返回的multiValueHeader写入响应头中，解决请求的响应头是数组类型但是被serverlessHandler处理成了字符串的问题